### PR TITLE
Ignore other Dockerfiles better to allow users to have their own Dockerfile(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 config.yaml
 
+# allows users to define their own Dockerfiles, like heroku.Dockerfile, etc
+**/*.Dockerfile
+
 # Created by https://www.toptal.com/developers/gitignore/api/pycharm+all
 # Edit at https://www.toptal.com/developers/gitignore?templates=pycharm+all
 


### PR DESCRIPTION
I'm deploying this to fly.io, so I have a `fly.Dockerfile` with my own customizations that shouldn't be included in source control.  This PR's only change is to ignore `**/*.Dockerfile`.